### PR TITLE
High-precision numbers cannot be empty

### DIFF
--- a/spec12/value-types.html
+++ b/spec12/value-types.html
@@ -244,7 +244,7 @@ There are 8 numeric types in Universal Binary JSON and are defined as:
 <td> 1-byte + int num val + string byte len</td>
 <td> H</td>
 <td> Yes</td>
-<td> Yes (if non-empty)</td>
+<td> Yes</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
The spec states that:

> High-precision number values must be written out in accordance with the original JSON number type specification.

The JSON specification does not allow numbers to be empty.