### PR TITLE
Clarify the semantics of the "char" type

### DIFF
--- a/spec12/value-types.html
+++ b/spec12/value-types.html
@@ -415,7 +415,7 @@ The <i>char </i>type in Universal Binary JSON is an unsigned byte meant to repre
 
 [box type="note"]The <em>char</em> type is synonymous with 1-byte, UTF8 encoded value (decimal values 0-127). A <em>char</em> value <strong>must not</strong> have a decimal value larger than 127.[/box]
 
-The <em>char</em> type is functionally identical to the <a href="#numeric"><em>uint8</em> type</a>, but semantically is meant to represent a character and not a numeric value.
+The <em>char</em> type is functionally identical to the <a href="#numeric"><em>uint8</em> type</a>, but semantically is meant to represent a string consisting of a single ASCII character, not a numeric value.
 <h3><a name="string-example"></a>Example</h3>
 JSON snippet:
 <pre lang="Javascript">{


### PR DESCRIPTION
There is no such thing as a "character" in the JSON data model.

This specification provides an example where an UBJSON "char" is mapped to a JSON string. Make explicit that this is what a "char" is intended to represent.